### PR TITLE
feat: 新增 Linux (fcitx5) 安裝腳本及安裝說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 - **macOS**: 鼠鬚管 ([Squirrel](https://github.com/rime/squirrel/releases))
 - **Windows**: 小狼毫 ([Weasel](https://github.com/rime/weasel/releases))
+- **Linux (Arch)**: fcitx5-rime (`sudo pacman -S fcitx5-rime`)
+- **Linux (Debian/Ubuntu)**: fcitx5-rime (`sudo apt install fcitx5-rime`)
 
 ### 手動安裝步驟
 
@@ -37,10 +39,13 @@
 2. 將檔案複製到 Rime 使用者資料夾：
    - **macOS**: `~/Library/Rime/`
    - **Windows**: `%AppData%\Rime\`
+   - **Linux (fcitx5)**: `~/.local/share/fcitx5/rime/`
+   - **Linux (ibus)**: `~/.config/ibus/rime/`
 3. 選擇版本：
    - **基礎版（中打不含英文詞庫）**：從 `configs` 資料夾複製 `liur.chinese-only.schema.yaml` 到 Rime 使用者資料夾，並重新命名為 `liur.schema.yaml`
    - **完整版（中打含英文詞庫版）**：從 `configs` 資料夾複製 `liur.schema.yaml` 到 Rime 使用者資料夾
-4. 重新部署 Rime
+4. **Linux 使用者**：需建立共用預設檔案的符號連結（`default.yaml`、`key_bindings.yaml`、`punctuation.yaml`），詳見下方 Linux 安裝說明
+5. 重新部署 Rime
 
 ### 指令安裝步驟
 
@@ -65,6 +70,96 @@ irm https://raw.githubusercontent.com/ryanwuson/rime-liur/main/rime_liur_install
 腳本會自動下載所需檔案並安裝字體
 
 ![readme-win](docs/images/readme-win.png)
+
+#### Linux（Arch Linux / Debian / Ubuntu）
+
+##### 前置需求
+
+**Arch Linux**：
+```bash
+sudo pacman -S fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool fcitx5-rime
+```
+
+**Debian / Ubuntu**：
+```bash
+sudo apt install fcitx5 fcitx5-rime fcitx5-config-qt
+```
+
+> 安裝完成後，請確認已將 fcitx5 設為系統輸入法框架。可在 `~/.pam_environment`、`~/.xprofile` 或 `/etc/environment` 中加入：
+> ```
+> GTK_IM_MODULE=fcitx
+> QT_IM_MODULE=fcitx
+> XMODIFIERS=@im=fcitx
+> ```
+
+##### 自動安裝
+
+打開終端機，輸入以下指令：
+```bash
+curl -fsSL https://raw.githubusercontent.com/ryanwuson/rime-liur/main/rime_liur_installer_linux.sh | bash
+```
+
+安裝腳本提供以下功能：
+
+1. **輸入方案版本選擇**：完整版（含英文詞庫）或基礎版（純中文）
+2. **自定義設定檔保留**：可選擇保留或覆蓋現有設定
+3. **額外輸入方案選擇**（可選）：
+   - 台灣注音（bopomofo）
+   - 日文輸入（rime-japanese）
+   - 注音 + 日文
+4. **自動安裝字體**並更新字體快取
+5. **自動部署** fcitx5-rime
+
+##### 手動安裝注意事項
+
+若選擇手動安裝，除了複製方案檔案外，還需建立共用預設檔案的符號連結：
+
+```bash
+RIME_FOLDER="$HOME/.local/share/fcitx5/rime"
+RIME_SHARED="/usr/share/rime-data"
+
+ln -sf "$RIME_SHARED/default.yaml" "$RIME_FOLDER/default.yaml"
+ln -sf "$RIME_SHARED/key_bindings.yaml" "$RIME_FOLDER/key_bindings.yaml"
+ln -sf "$RIME_SHARED/punctuation.yaml" "$RIME_FOLDER/punctuation.yaml"
+```
+
+這些檔案包含 Rime 引擎所需的預設標點、鍵位繫結等設定，缺少會導致部署失敗。
+
+##### 額外輸入方案安裝
+
+**台灣注音（Arch）**：
+```bash
+sudo pacman -S rime-bopomofo
+```
+
+**台灣注音（Debian/Ubuntu）**：
+```bash
+sudo apt install rime-data-bopomofo
+```
+
+**日文輸入**（需手動下載 [rime-japanese](https://github.com/gkovacs/rime-japanese)）：
+```bash
+RIME_FOLDER="$HOME/.local/share/fcitx5/rime"
+JAPANESE_RAW="https://raw.githubusercontent.com/gkovacs/rime-japanese/master"
+
+for f in japanese.schema.yaml japanese.dict.yaml japanese.mozc.dict.yaml japanese.jmdict.dict.yaml japanese.kana.dict.yaml; do
+    curl -fsSL "$JAPANESE_RAW/$f" -o "$RIME_FOLDER/$f"
+done
+```
+
+安裝完成後，在 `default.custom.yaml` 的 `schema_list` 中加入對應方案：
+```yaml
+schema_list:
+  - schema: liur
+  - schema: easy_en
+  - schema: bopomofo_tw    # 台灣注音
+  - schema: japanese        # 日文
+```
+
+然後重新部署 Rime：
+```bash
+fcitx5-remote -r
+```
 
 ### 基本使用
 
@@ -112,6 +207,13 @@ irm https://raw.githubusercontent.com/ryanwuson/rime-liur/main/rime_liur_install
 - SourceHanSansTC-Regular.otf
 - PlangothicP1-Regular.ttf
 - PlangothicP2-Regular.ttf
+
+**Linux**:
+- MapleMonoNormal-Regular.ttf
+- PlangothicP1-Regular.ttf
+- PlangothicP2-Regular.ttf
+
+> Linux 字體安裝路徑為 `~/.local/share/fonts/`，安裝後執行 `fc-cache -f` 更新字體快取。
 
 ## 授權
 

--- a/configs/liur.chinese-only.schema.yaml
+++ b/configs/liur.chinese-only.schema.yaml
@@ -44,18 +44,18 @@ switches:
 engine:
   processors:
     - ascii_composer
-    - lua_processor@liu_schema_switch_processor      # 方案切換狀態保持（必須在 key_binder 之前攔截 Ctrl+/）
-    - lua_processor@liu_tilde_processor              # 波浪號直出（必須在 recognizer 之前）
-    - lua_processor@liu_fancy_processor              # 變體英數模式按鍵處理（必須在 recognizer 之前攔截 ` 鍵）
-    - lua_processor@liu_extended_backspace           # `` 擴充模式（必須在 recognizer 之前攔截 ` 鍵）
-    - lua_processor@liu_symbols_number_processor     # 符號清單數字選字及字母變化形（必須在 recognizer 之前攔截 ` 鍵）
+    - lua_processor@*liu_schema_switch_processor      # 方案切換狀態保持（必須在 key_binder 之前攔截 Ctrl+/）
+    - lua_processor@*liu_tilde_processor              # 波浪號直出（必須在 recognizer 之前）
+    - lua_processor@*liu_fancy_processor              # 變體英數模式按鍵處理（必須在 recognizer 之前攔截 ` 鍵）
+    - lua_processor@*liu_extended_backspace           # `` 擴充模式（必須在 recognizer 之前攔截 ` 鍵）
+    - lua_processor@*liu_symbols_number_processor     # 符號清單數字選字及字母變化形（必須在 recognizer 之前攔截 ` 鍵）
     - recognizer
-    - lua_processor@liu_wildcard_processor           # 萬用字元開關（關閉時 ? 直接輸出）
-    - lua_processor@liu_quick_mode_processor         # 處理 ,,sp 切換快打模式
-    - lua_processor@liu_phonetic_hint_processor      # 讀音查詢模式下屏蔽 ctrl+'
-    - lua_processor@liu_symbols_processor            # 符號清單模式下屏蔽 ctrl+'
-    - lua_processor@liu_phonetic_suffix_processor    # 同音字模式（選中後按 '）
-    - lua_processor@liu_gc_processor                 # 上屏後小步垃圾回收
+    - lua_processor@*liu_wildcard_processor           # 萬用字元開關（關閉時 ? 直接輸出）
+    - lua_processor@*liu_quick_mode_processor         # 處理 ,,sp 切換快打模式
+    - lua_processor@*liu_phonetic_hint_processor      # 讀音查詢模式下屏蔽 ctrl+'
+    - lua_processor@*liu_symbols_processor            # 符號清單模式下屏蔽 ctrl+'
+    - lua_processor@*liu_phonetic_suffix_processor    # 同音字模式（選中後按 '）
+    - lua_processor@*liu_gc_processor                 # 上屏後小步垃圾回收
     - key_binder
     - speller
 #    - punctuator
@@ -66,7 +66,7 @@ engine:
   segmentors:
     - ascii_segmentor
     - matcher
-    - lua_segmentor@liu_extended_segmentor  # 擴充模式 ``（lua segmentor 處理空輸入）
+    - lua_segmentor@*liu_extended_segmentor  # 擴充模式 ``（lua segmentor 處理空輸入）
     - affix_segmentor@extended_mode  # 擴充模式 ``（必須在 fancy 之前）
     - affix_segmentor@fancy_number  # 變體數字 `/'
     - affix_segmentor@fancy_upper   # 變體AA `///
@@ -89,19 +89,19 @@ engine:
 #    - echo_translator
 #    - punct_translator
 #    - script_translator
-    - lua_translator@liu_help_translator  # 功能說明（,,h 模式）- 必須在最前面
-    - lua_translator@liu_symbols_hint  # 符號清單提示
-    - lua_translator@liu_letter_variants  # 擴充模式字母變化形（``a 小寫，``A 大寫）
-    - lua_translator@liu_datetime  # 擴充模式日期時間（``/01~``/10）
-    - lua_translator@liu_fancy_translator  # 變體英數轉換器（`/ `// `/// `/'）
-    - lua_translator@date_translator  # 符號清單變體（`a 字母變體，`01 數字變體）
-    - lua_translator@liu_phonetic_suffix_translator  # 同音字翻譯器（選中後按 '）
-    - lua_translator@liu_code_decoder_translator  # 編碼解碼器（,,x 模式）
+    - lua_translator@*liu_help_translator  # 功能說明（,,h 模式）- 必須在最前面
+    - lua_translator@*liu_symbols_hint_translator  # 符號清單提示
+    - lua_translator@*liu_letter_variants  # 擴充模式字母變化形（``a 小寫，``A 大寫）
+    - lua_translator@*liu_datetime  # 擴充模式日期時間（``/01~``/10）
+    - lua_translator@*liu_fancy_translator  # 變體英數轉換器（`/ `// `/// `/'）
+    - lua_translator@*liu_date_translator  # 符號清單變體（`a 字母變體，`01 數字變體）
+    - lua_translator@*liu_phonetic_suffix_translator  # 同音字翻譯器（選中後按 '）
+    - lua_translator@*liu_code_decoder_translator  # 編碼解碼器（,,x 模式）
     - script_translator@all_bpm
     - table_translator@mkst
     - table_translator@fixed
     - table_translator@liurqry
-    - lua_translator@liu_custom_word_translator  # 自定詞翻譯器（在 table_translator 之前）
+    - lua_translator@*liu_custom_word_translator  # 自定詞翻譯器（在 table_translator 之前）
     - table_translator
     # - table_translator@easy_en  # 英文輸入（已註解 - 純中文版）
     - script_translator@pinyin  # 漢語拼音（;' 引導）
@@ -109,27 +109,27 @@ engine:
     - table_translator@symbols
 
   filters:
-    - lua_filter@liu_custom_word_filter	#候選排序：漢字 > 自定詞 > 假名 > 擴充（已移除英文排序）
-    - lua_filter@liu_charset_filter	#自定義字符集過濾（CJK Compatibility Forms 視為常用字集）
-    - lua_filter@liu_wildcard_filter	#查碼模式下禁用萬用字元
-    - lua_filter@liu_wildcard_code_hint	#萬用字元查詢時顯示編碼
+    - lua_filter@*liu_custom_word_filter	#候選排序：漢字 > 自定詞 > 假名 > 擴充（已移除英文排序）
+    - lua_filter@*liu_charset_filter	#自定義字符集過濾（CJK Compatibility Forms 視為常用字集）
+    - lua_filter@*liu_wildcard_filter	#查碼模式下禁用萬用字元
+    - lua_filter@*liu_wildcard_code_hint	#萬用字元查詢時顯示編碼
     - simplifier@liu_w2c	#無蝦米字碼查詢 - 必須在 simplifier 之前
     - reverse_lookup_filter@phonetic_reverse_lookup	#讀音查詢（必須在 simplifier 之前以查詢繁體字）
     - simplifier
-    - lua_filter@liu_extended_filter	#擴充模式處理（禁用反查和簡體）- 必須在 simplifier 之後
-    - lua_filter@liu_remove_trad_in_w2c	#查碼模式下移除繁體標記
-    - lua_filter@liu_w2c_sorter	#字碼排序及簡體模式優化
-    - lua_filter@liu_vrsf_hint	#VRSF 選字提示（▸ ⟨v⟩ 等）- 必須在 liu_w2c_sorter 之後
-    - lua_filter@liu_quick_hint	#快打模式：提示可用簡碼（必須在 liu_w2c_sorter 之後以覆蓋繁體標記）
-    - lua_filter@liu_phonetic_suffix_filter	#嘸蝦米同音字（選中後按 '）- 必須在 simplifier 之後
+    - lua_filter@*liu_extended_filter	#擴充模式處理（禁用反查和簡體）- 必須在 simplifier 之後
+    - lua_filter@*liu_remove_trad_in_w2c	#查碼模式下移除繁體標記
+    - lua_filter@*liu_w2c_sorter	#字碼排序及簡體模式優化
+    - lua_filter@*liu_vrsf_hint	#VRSF 選字提示（▸ ⟨v⟩ 等）- 必須在 liu_w2c_sorter 之後
+    - lua_filter@*liu_quick_hint	#快打模式：提示可用簡碼（必須在 liu_w2c_sorter 之後以覆蓋繁體標記）
+    - lua_filter@*liu_phonetic_suffix_filter	#嘸蝦米同音字（選中後按 '）- 必須在 simplifier 之後
     - simplifier@zh_tw
     # - reverse_lookup_filter@ovff_reverse_lookup  # 未定義，暫時註解
-    - lua_filter@liu_phonetic_override	#讀音查詢模式下移除編碼和繁體標記（必須在最後）
-    - lua_filter@liu_symbols_hint_filter	#符號清單提示處理（必須在所有 simplifier 之後，uniquifier 之前）
-    - lua_filter@liu_help_filter	#按鍵說明處理（必須在所有 simplifier 之後）
-    - lua_filter@liu_fancy_filter	#變體英數模式 preedit 處理
-    # - lua_filter@liu_english_case_filter	#英文大小寫轉換（已註解 - 純中文版）
-    # - lua_filter@liu_english_filter	#移除英文候選的補全提示（已註解 - 純中文版）
+    - lua_filter@*liu_phonetic_override	#讀音查詢模式下移除編碼和繁體標記（必須在最後）
+    - lua_filter@*liu_symbols_hint_filter	#符號清單提示處理（必須在所有 simplifier 之後，uniquifier 之前）
+    - lua_filter@*liu_help_filter	#按鍵說明處理（必須在所有 simplifier 之後）
+    - lua_filter@*liu_fancy_filter	#變體英數模式 preedit 處理
+    # - lua_filter@*liu_english_case_filter	#英文大小寫轉換（已註解 - 純中文版）
+    # - lua_filter@*liu_english_filter	#移除英文候選的補全提示（已註解 - 純中文版）
     - uniquifier	#過濾重複的候選字（必須在所有 filter 之後）
     # - single_char_filter  #單字優先
 

--- a/configs/liur.schema.yaml
+++ b/configs/liur.schema.yaml
@@ -42,18 +42,18 @@ switches:
 engine:
   processors:
     - ascii_composer
-    - lua_processor@liu_schema_switch_processor      # 方案切換狀態保持（必須在 key_binder 之前攔截 Ctrl+/）
-    - lua_processor@liu_tilde_processor              # 波浪號直出（必須在 recognizer 之前）
-    - lua_processor@liu_fancy_processor              # 變體英數模式按鍵處理（必須在 recognizer 之前攔截 ` 鍵）
-    - lua_processor@liu_extended_backspace           # `` 擴充模式（必須在 recognizer 之前攔截 ` 鍵）
-    - lua_processor@liu_symbols_number_processor     # 符號清單數字選字及字母變化形（必須在 recognizer 之前攔截 ` 鍵）
+    - lua_processor@*liu_schema_switch_processor      # 方案切換狀態保持（必須在 key_binder 之前攔截 Ctrl+/）
+    - lua_processor@*liu_tilde_processor              # 波浪號直出（必須在 recognizer 之前）
+    - lua_processor@*liu_fancy_processor              # 變體英數模式按鍵處理（必須在 recognizer 之前攔截 ` 鍵）
+    - lua_processor@*liu_extended_backspace           # `` 擴充模式（必須在 recognizer 之前攔截 ` 鍵）
+    - lua_processor@*liu_symbols_number_processor     # 符號清單數字選字及字母變化形（必須在 recognizer 之前攔截 ` 鍵）
     - recognizer
-    - lua_processor@liu_wildcard_processor           # 萬用字元開關（關閉時 ? 直接輸出）
-    - lua_processor@liu_quick_mode_processor         # 處理 ,,sp 切換快打模式
-    - lua_processor@liu_phonetic_hint_processor      # 讀音查詢模式下屏蔽 ctrl+'
-    - lua_processor@liu_symbols_processor            # 符號清單模式下屏蔽 ctrl+'
-    - lua_processor@liu_phonetic_suffix_processor    # 同音字模式（選中後按 '）
-    - lua_processor@liu_gc_processor                 # 上屏後小步垃圾回收
+    - lua_processor@*liu_wildcard_processor           # 萬用字元開關（關閉時 ? 直接輸出）
+    - lua_processor@*liu_quick_mode_processor         # 處理 ,,sp 切換快打模式
+    - lua_processor@*liu_phonetic_hint_processor      # 讀音查詢模式下屏蔽 ctrl+'
+    - lua_processor@*liu_symbols_processor            # 符號清單模式下屏蔽 ctrl+'
+    - lua_processor@*liu_phonetic_suffix_processor    # 同音字模式（選中後按 '）
+    - lua_processor@*liu_gc_processor                 # 上屏後小步垃圾回收
     - key_binder
     - speller
 #    - punctuator
@@ -64,7 +64,7 @@ engine:
   segmentors:
     - ascii_segmentor
     - matcher
-    - lua_segmentor@liu_extended_segmentor  # 擴充模式 ``（lua segmentor 處理空輸入）
+    - lua_segmentor@*liu_extended_segmentor  # 擴充模式 ``（lua segmentor 處理空輸入）
     - affix_segmentor@extended_mode  # 擴充模式 ``（必須在 fancy 之前）
     - affix_segmentor@fancy_number  # 變體數字 `/'
     - affix_segmentor@fancy_upper   # 變體AA `///
@@ -87,19 +87,19 @@ engine:
 #    - echo_translator
 #    - punct_translator
 #    - script_translator
-    - lua_translator@liu_help_translator  # 功能說明（,,h 模式）- 必須在最前面
-    - lua_translator@liu_symbols_hint  # 符號清單提示
-    - lua_translator@liu_letter_variants  # 擴充模式字母變化形（``a 小寫，``A 大寫）
-    - lua_translator@liu_datetime  # 擴充模式日期時間（``/01~``/10）
-    - lua_translator@liu_fancy_translator  # 變體英數轉換器（`/ `// `/// `/'）
-    - lua_translator@date_translator  # 符號清單變體（`a 字母變體，`01 數字變體）
-    - lua_translator@liu_phonetic_suffix_translator  # 同音字翻譯器（選中後按 '）
-    - lua_translator@liu_code_decoder_translator  # 編碼解碼器（,,x 模式）
+    - lua_translator@*liu_help_translator  # 功能說明（,,h 模式）- 必須在最前面
+    - lua_translator@*liu_symbols_hint_translator  # 符號清單提示
+    - lua_translator@*liu_letter_variants  # 擴充模式字母變化形（``a 小寫，``A 大寫）
+    - lua_translator@*liu_datetime  # 擴充模式日期時間（``/01~``/10）
+    - lua_translator@*liu_fancy_translator  # 變體英數轉換器（`/ `// `/// `/'）
+    - lua_translator@*liu_date_translator  # 符號清單變體（`a 字母變體，`01 數字變體）
+    - lua_translator@*liu_phonetic_suffix_translator  # 同音字翻譯器（選中後按 '）
+    - lua_translator@*liu_code_decoder_translator  # 編碼解碼器（,,x 模式）
     - script_translator@all_bpm
     - table_translator@mkst
     - table_translator@fixed
     - table_translator@liurqry
-    - lua_translator@liu_custom_word_translator  # 自定詞翻譯器（在 table_translator 之前）
+    - lua_translator@*liu_custom_word_translator  # 自定詞翻譯器（在 table_translator 之前）
     - table_translator
     - table_translator@easy_en  # 英文輸入（獨立翻譯器）
     - script_translator@pinyin  # 漢語拼音（;' 引導）
@@ -107,27 +107,27 @@ engine:
     - table_translator@symbols
 
   filters:
-    - lua_filter@liu_custom_word_filter	#候選排序：漢字 > 自定詞 > 假名 > 擴充 > 英文
-    - lua_filter@liu_charset_filter	#自定義字符集過濾（CJK Compatibility Forms 視為常用字集）
-    - lua_filter@liu_wildcard_filter	#查碼模式下禁用萬用字元
-    - lua_filter@liu_wildcard_code_hint	#萬用字元查詢時顯示編碼
+    - lua_filter@*liu_custom_word_filter	#候選排序：漢字 > 自定詞 > 假名 > 擴充 > 英文
+    - lua_filter@*liu_charset_filter	#自定義字符集過濾（CJK Compatibility Forms 視為常用字集）
+    - lua_filter@*liu_wildcard_filter	#查碼模式下禁用萬用字元
+    - lua_filter@*liu_wildcard_code_hint	#萬用字元查詢時顯示編碼
     - simplifier@liu_w2c	#無蝦米字碼查詢 - 必須在 simplifier 之前
     - reverse_lookup_filter@phonetic_reverse_lookup	#讀音查詢（必須在 simplifier 之前以查詢繁體字）
     - simplifier
-    - lua_filter@liu_extended_filter	#擴充模式處理（禁用反查和簡體）- 必須在 simplifier 之後
-    - lua_filter@liu_remove_trad_in_w2c	#查碼模式下移除繁體標記
-    - lua_filter@liu_w2c_sorter	#字碼排序及簡體模式優化
-    - lua_filter@liu_vrsf_hint	#VRSF 選字提示（▸ ⟨v⟩ 等）- 必須在 liu_w2c_sorter 之後
-    - lua_filter@liu_quick_hint	#快打模式：提示可用簡碼（必須在 liu_w2c_sorter 之後以覆蓋繁體標記）
-    - lua_filter@liu_phonetic_suffix_filter	#嘸蝦米同音字（選中後按 '）- 必須在 simplifier 之後
+    - lua_filter@*liu_extended_filter	#擴充模式處理（禁用反查和簡體）- 必須在 simplifier 之後
+    - lua_filter@*liu_remove_trad_in_w2c	#查碼模式下移除繁體標記
+    - lua_filter@*liu_w2c_sorter	#字碼排序及簡體模式優化
+    - lua_filter@*liu_vrsf_hint	#VRSF 選字提示（▸ ⟨v⟩ 等）- 必須在 liu_w2c_sorter 之後
+    - lua_filter@*liu_quick_hint	#快打模式：提示可用簡碼（必須在 liu_w2c_sorter 之後以覆蓋繁體標記）
+    - lua_filter@*liu_phonetic_suffix_filter	#嘸蝦米同音字（選中後按 '）- 必須在 simplifier 之後
     - simplifier@zh_tw
     # - reverse_lookup_filter@ovff_reverse_lookup  # 未定義，暫時註解
-    - lua_filter@liu_phonetic_override	#讀音查詢模式下移除編碼和繁體標記（必須在最後）
-    - lua_filter@liu_symbols_hint_filter	#符號清單提示處理（必須在所有 simplifier 之後，uniquifier 之前）
-    - lua_filter@liu_help_filter	#按鍵說明處理（必須在所有 simplifier 之後）
-    - lua_filter@liu_fancy_filter	#變體英數模式 preedit 處理
-    - lua_filter@liu_english_case_filter	#英文大小寫轉換（word] → Word，word]] → WORD）
-    - lua_filter@liu_english_filter	#移除英文候選的補全提示（必須在 uniquifier 之前）
+    - lua_filter@*liu_phonetic_override	#讀音查詢模式下移除編碼和繁體標記（必須在最後）
+    - lua_filter@*liu_symbols_hint_filter	#符號清單提示處理（必須在所有 simplifier 之後，uniquifier 之前）
+    - lua_filter@*liu_help_filter	#按鍵說明處理（必須在所有 simplifier 之後）
+    - lua_filter@*liu_fancy_filter	#變體英數模式 preedit 處理
+    - lua_filter@*liu_english_case_filter	#英文大小寫轉換（word] → Word，word]] → WORD）
+    - lua_filter@*liu_english_filter	#移除英文候選的補全提示（必須在 uniquifier 之前）
     - uniquifier	#過濾重複的候選字（必須在所有 filter 之後）
     # - single_char_filter  #單字優先
 

--- a/lua/liu_code_decoder_translator.lua
+++ b/lua/liu_code_decoder_translator.lua
@@ -1,0 +1,2 @@
+-- Wrapper for @* syntax: liu_code_decoder_translator → liu_code_decoder module
+return require("liu_code_decoder")

--- a/lua/liu_custom_word_translator.lua
+++ b/lua/liu_custom_word_translator.lua
@@ -92,9 +92,9 @@ local function load_custom_words()
         local file = io.open(path, "r")
         if file then
             local in_data = false
-            for line in file:lines() do
+            for raw_line in file:lines() do
                 -- 移除 Windows 換行符 \r
-                line = line:gsub("\r$", "")
+                local line = raw_line:gsub("\r$", "")
                 if line == "..." then
                     in_data = true
                 elseif in_data and #line > 0 and line:byte(1) ~= 35 then  -- 35 = '#'

--- a/lua/liu_date_translator.lua
+++ b/lua/liu_date_translator.lua
@@ -1,0 +1,63 @@
+-- liu_date_translator.lua
+-- 符號表變體處理（`a 字母變體，`'01 數字變體）
+-- Extracted from rime.lua for @* syntax compatibility
+
+local symbol_data = require("liu_symbol_data")
+local number_symbols = symbol_data.number_symbols
+local letter_symbols = symbol_data.letter_symbols
+
+local function translator(input, seg)
+  -- 擴充模式（``）由 liu_letter_variants.lua 和 liu_datetime.lua 處理
+  if seg:has_tag("extended_mode") then
+    return
+  end
+
+  -- 數字變體模式（`'）
+  if seg:has_tag("number_variant") then
+    -- 空輸入：顯示等待提示
+    if input == "" then
+      yield(Candidate("number_variant_hint", seg.start, seg._end, "請輸入數字 (00~50)", ""))
+      return
+    end
+
+    -- 只有1位數字：顯示等待提示
+    local single_digit = string.match(input, "^(%d)$")
+    if single_digit then
+      local cand = Candidate("number_variant_hint", seg.start, seg._end, "請輸入第二位數字 (00~50)", "")
+      cand.preedit = "《變體數字》" .. single_digit
+      yield(cand)
+      return
+    end
+
+    -- 數字變體：`'01 到 `'50（必須兩位數字）
+    local num = string.match(input, "^(%d%d)$")
+    if num then
+      local num_key = tostring(tonumber(num))  -- 去掉前導零：01 → 1
+      if number_symbols[num_key] then
+        local preedit = "《變體" .. num_key .. "》" .. num
+        for _, symbol in ipairs(number_symbols[num_key]) do
+          local cand = Candidate("number_variant", seg.start, seg._end, symbol, "")
+          cand.preedit = preedit
+          yield(cand)
+        end
+      end
+    end
+    return
+  end
+
+  -- 符號表模式（`）- 處理字母變體（Ⓐ）
+  if seg:has_tag("symbols") then
+    local letter = string.match(input, "^([a-z])$")
+    if letter and letter_symbols[letter] then
+      local preedit = "《變體" .. letter .. "》" .. letter
+      for _, symbol in ipairs(letter_symbols[letter]) do
+        local cand = Candidate("letter_variant", seg.start, seg._end, symbol, "")
+        cand.preedit = preedit
+        yield(cand)
+      end
+    end
+    return
+  end
+end
+
+return translator

--- a/lua/liu_help_translator.lua
+++ b/lua/liu_help_translator.lua
@@ -1,0 +1,2 @@
+-- Wrapper for @* syntax: extract translator from liu_help module
+return require("liu_help").translator

--- a/lua/liu_phonetic_suffix.lua
+++ b/lua/liu_phonetic_suffix.lua
@@ -80,8 +80,8 @@ local function parse_codes(codes_str)
     local secondary = {}
     
     local temp_str = codes_str:gsub("\\⟩", "\x01")
-    for code in temp_str:gmatch("⟨([^⟩]+)⟩") do
-        code = code:gsub("\x01", "⟩"):upper()
+    for raw_code in temp_str:gmatch("⟨([^⟩]+)⟩") do
+        local code = raw_code:gsub("\x01", "⟩"):upper()
         if code:match("%^[VRSF]") then
             secondary[#secondary + 1] = code
         else

--- a/lua/liu_phonetic_suffix_filter.lua
+++ b/lua/liu_phonetic_suffix_filter.lua
@@ -1,0 +1,2 @@
+-- Wrapper for @* syntax: extract filter from liu_phonetic_suffix module
+return require("liu_phonetic_suffix").filter

--- a/lua/liu_phonetic_suffix_processor.lua
+++ b/lua/liu_phonetic_suffix_processor.lua
@@ -1,0 +1,2 @@
+-- Wrapper for @* syntax: extract processor from liu_phonetic_suffix module
+return require("liu_phonetic_suffix").processor

--- a/lua/liu_phonetic_suffix_translator.lua
+++ b/lua/liu_phonetic_suffix_translator.lua
@@ -1,0 +1,2 @@
+-- Wrapper for @* syntax: extract translator from liu_phonetic_suffix module
+return require("liu_phonetic_suffix").translator

--- a/lua/liu_quick_hint.lua
+++ b/lua/liu_quick_hint.lua
@@ -34,8 +34,8 @@ local function find_shortest_codes(codes_str, max_len)
     -- 解析 ⟨code⟩ 格式的編碼
     -- 先處理跳脫的 ⟩
     codes_str = codes_str:gsub("\\⟩", "\x01")
-    for code in codes_str:gmatch("⟨([^⟩]+)⟩") do
-        code = code:gsub("\x01", "⟩")
+    for raw_code in codes_str:gmatch("⟨([^⟩]+)⟩") do
+        local code = raw_code:gsub("\x01", "⟩")
         
         -- 只考慮「第一候選」的編碼（沒有 ^ 的）
         -- 有 ^ 的是選字輔碼，不算簡碼

--- a/lua/liu_remove_trad_in_w2c.lua
+++ b/lua/liu_remove_trad_in_w2c.lua
@@ -51,9 +51,9 @@ local function liu_remove_trad_in_w2c(input, env)
                     local codes = {}
                     -- 先將 \⟩ 替換為臨時標記
                     codes_str = codes_str:gsub("\\⟩", "\x01")
-                    for code in codes_str:gmatch("⟨([^⟩]+)⟩") do
+                    for raw_code in codes_str:gmatch("⟨([^⟩]+)⟩") do
                         -- 將臨時標記還原為 ⟩
-                        code = code:gsub("\x01", "⟩")
+                        local code = raw_code:gsub("\x01", "⟩")
                         table.insert(codes, "⟨" .. code .. "⟩")
                     end
                     if #codes > 0 then
@@ -73,9 +73,9 @@ local function liu_remove_trad_in_w2c(input, env)
                 local codes = {}
                 -- 先將 \⟩ 替換為臨時標記
                 local temp_comment = comment:gsub("\\⟩", "\x01")
-                for code in temp_comment:gmatch("⟨([^⟩]+)⟩") do
+                for raw_code in temp_comment:gmatch("⟨([^⟩]+)⟩") do
                     -- 將臨時標記還原為 ⟩
-                    code = code:gsub("\x01", "⟩")
+                    local code = raw_code:gsub("\x01", "⟩")
                     table.insert(codes, code)
                 end
                 

--- a/lua/liu_symbols_hint_translator.lua
+++ b/lua/liu_symbols_hint_translator.lua
@@ -1,0 +1,2 @@
+-- Wrapper for @* syntax: extract translator from liu_symbols_hint module
+return require("liu_symbols_hint").translator

--- a/lua/liu_w2c_sorter.lua
+++ b/lua/liu_w2c_sorter.lua
@@ -230,9 +230,9 @@ local function liu_w2c_sorter(input, env)
                         local codes = {}
                         -- 先將 \⟩ 替換為臨時標記
                         local temp_group = group_str:gsub("\\⟩", "\x01")
-                        for code in temp_group:gmatch("⟨([^⟩]+)⟩") do
+                        for raw_code in temp_group:gmatch("⟨([^⟩]+)⟩") do
                             -- 將臨時標記還原為 ⟩
-                            code = code:gsub("\x01", "⟩")
+                            local code = raw_code:gsub("\x01", "⟩")
                             table.insert(codes, code)
                         end
                         
@@ -262,9 +262,9 @@ local function liu_w2c_sorter(input, env)
                     local codes = {}
                     -- 先將 \⟩ 替換為臨時標記
                     local temp_comment = comment:gsub("\\⟩", "\x01")
-                    for code in temp_comment:gmatch("⟨([^⟩]+)⟩") do
+                    for raw_code in temp_comment:gmatch("⟨([^⟩]+)⟩") do
                         -- 將臨時標記還原為 ⟩
-                        code = code:gsub("\x01", "⟩")
+                        local code = raw_code:gsub("\x01", "⟩")
                         table.insert(codes, code)
                     end
                     

--- a/rime_liur_installer_linux.sh
+++ b/rime_liur_installer_linux.sh
@@ -263,7 +263,7 @@ mkdir -p "$RIME_FOLDER/configs"
 # 建立共用 rime 預設檔案的符號連結（fcitx5-rime 需要這些）
 RIME_SHARED="/usr/share/rime-data"
 for preset in default.yaml key_bindings.yaml punctuation.yaml; do
-    if [ -f "$RIME_SHARED/$preset" ] && [ ! -f "$RIME_FOLDER/$preset" ]; then
+    if [ -f "$RIME_SHARED/$preset" ]; then
         ln -sf "$RIME_SHARED/$preset" "$RIME_FOLDER/$preset"
     fi
 done
@@ -502,7 +502,7 @@ if command -v fcitx5-remote &>/dev/null; then
     sleep 1
     # 觸發 rime 重新部署
     if command -v rime_deployer &>/dev/null; then
-        rime_deployer --build "$RIME_FOLDER" 2>/dev/null || true
+        rime_deployer --build "$RIME_FOLDER" "$RIME_SHARED" 2>/dev/null || true
     fi
     fcitx5-remote -r 2>/dev/null || true
     echo -e "${GREEN}已重新部署 fcitx5-rime${NC}"

--- a/rime_liur_installer_linux.sh
+++ b/rime_liur_installer_linux.sh
@@ -1,0 +1,530 @@
+#!/usr/bin/env bash
+# RIME 蝦米輸入方案自動安裝工具 (Linux / fcitx5)
+# based on macOS version by Ryan Chou
+# adapted for Arch Linux / fcitx5-rime
+
+set -e
+
+# 顏色定義
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# GitHub 相關設定
+GITHUB_REPO="ryanwuson/rime-liur"
+GITHUB_BRANCH="main"
+GITHUB_API="https://api.github.com/repos/${GITHUB_REPO}/git/trees/${GITHUB_BRANCH}?recursive=1"
+GITHUB_RAW="https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}"
+
+# Linux (fcitx5) 路徑設定
+RIME_FOLDER="$HOME/.local/share/fcitx5/rime"
+FONT_FOLDER="$HOME/.local/share/fonts"
+
+# 排除清單（正則表達式）- 排除 macOS/Windows 專用檔案
+EXCLUDE_PATTERNS="^docs/|^README\.md$|^LICENSE$|^\.gitignore$|^rime_liur_installer\.sh$|^rime_liur_installer\.ps1$|^rime_liur_installer_linux\.sh$|^fonts/Windows Only/|^squirrel\.custom\.yaml$|^weasel\.custom\.yaml$|^installation\.yaml$"
+
+# 進度條函數
+show_progress() {
+    local current=$1
+    local total=$2
+    local filename=$3
+    local width=20
+    local percent=$((current * 100 / total))
+    local filled=$((current * width / total))
+    local empty=$((width - filled))
+
+    local bar=""
+    for ((i=0; i<filled; i++)); do bar+="█"; done
+    for ((i=0; i<empty; i++)); do bar+="░"; done
+
+    if [ ${#filename} -gt 40 ]; then
+        filename="${filename:0:37}..."
+    fi
+
+    printf "\r  [%s] %3d/%d  %-45s" "$bar" "$current" "$total" "$filename"
+}
+
+echo
+echo "======================================"
+echo "  RIME 蝦米輸入方案 自動安裝工具"
+echo "  (Linux / fcitx5)"
+echo "======================================"
+echo
+
+# 檢查 fcitx5-rime
+if ! pacman -Qi fcitx5-rime &>/dev/null; then
+    echo -e "${RED}錯誤：尚未安裝 fcitx5-rime！${NC}"
+    echo "請先安裝："
+    echo "  sudo pacman -S fcitx5-rime"
+    echo
+    echo "若尚未安裝 fcitx5，請先執行："
+    echo "  sudo pacman -S fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool"
+    exit 1
+fi
+
+echo "本工具將執行以下作業："
+echo "1. 選擇輸入方案版本"
+echo "2. 下載蝦米輸入方案檔案到 Rime 資料夾"
+echo "3. 選擇額外輸入方案（注音、日文）"
+echo "4. 安裝所需字體"
+echo "5. 部署 RIME"
+echo
+
+echo -e "${YELLOW}※ 若有自訂設定尚未備份，請按 Ctrl+C 終止${NC}"
+echo
+
+# 版本選擇
+echo -e "${YELLOW}請選擇輸入方案版本：${NC}"
+echo
+echo "1. 完整版（中打含英文詞庫版）（推薦）"
+echo "   - 完整功能，中文輸入搭配英文詞庫輔助"
+echo "   - 英文詞庫支援，大小寫轉換"
+echo "   - 適合日常使用、程式開發"
+echo
+echo "2. 基礎版（中打不含英文詞庫）"
+echo "   - 專注中文輸入，不含英文詞庫"
+echo "   - 減少英文候選干擾"
+echo "   - 適合純中文寫作"
+echo
+
+while true; do
+    read -p "請輸入選項 (1 或 2): " choice < /dev/tty
+    case $choice in
+        1)
+            SCHEMA_VERSION="mixed"
+            echo -e "${GREEN}已選擇：完整版（中打含英文詞庫版）${NC}"
+            break
+            ;;
+        2)
+            SCHEMA_VERSION="chinese-only"
+            echo -e "${GREEN}已選擇：基礎版（中打不含英文詞庫）${NC}"
+            break
+            ;;
+        *)
+            echo -e "${RED}請輸入 1 或 2${NC}"
+            ;;
+    esac
+done
+
+echo
+
+# 自定義設定檔選項
+echo -e "${YELLOW}是否覆蓋自定義設定檔？${NC}"
+echo
+echo "以下檔案用於儲存您的個人設定與詞彙："
+echo "• openxiami_CustomWord.dict.yaml（自定義詞庫）"
+echo "• default.custom.yaml（全域設定）"
+echo
+echo "若您已有自訂設定，建議選擇「保留」以避免遺失。"
+echo
+echo "1. 保留（推薦）- 保留現有的自定義設定檔"
+echo "2. 覆蓋 - 下載預設設定檔（會清除您的自訂設定）"
+echo
+
+while true; do
+    read -p "請輸入選項 (1 或 2): " customChoice < /dev/tty
+    case $customChoice in
+        1)
+            KEEP_CUSTOM_FILES=true
+            echo -e "${GREEN}已選擇：保留自定義設定檔${NC}"
+            break
+            ;;
+        2)
+            KEEP_CUSTOM_FILES=false
+            echo -e "${GREEN}已選擇：覆蓋自定義設定檔${NC}"
+            break
+            ;;
+        *)
+            echo -e "${RED}請輸入 1 或 2${NC}"
+            ;;
+    esac
+done
+
+echo
+
+# 額外輸入方案選擇
+echo -e "${YELLOW}是否安裝額外輸入方案？${NC}"
+echo
+echo "1. 僅蝦米（不安裝額外方案）"
+echo "2. 加裝注音（台灣注音 bopomofo）"
+echo "3. 加裝日文（rime-japanese）"
+echo "4. 加裝注音 + 日文（推薦）"
+echo
+
+INSTALL_BOPOMOFO=false
+INSTALL_JAPANESE=false
+
+while true; do
+    read -p "請輸入選項 (1-4): " extraChoice < /dev/tty
+    case $extraChoice in
+        1)
+            echo -e "${GREEN}已選擇：僅蝦米${NC}"
+            break
+            ;;
+        2)
+            INSTALL_BOPOMOFO=true
+            echo -e "${GREEN}已選擇：加裝注音${NC}"
+            break
+            ;;
+        3)
+            INSTALL_JAPANESE=true
+            echo -e "${GREEN}已選擇：加裝日文${NC}"
+            break
+            ;;
+        4)
+            INSTALL_BOPOMOFO=true
+            INSTALL_JAPANESE=true
+            echo -e "${GREEN}已選擇：加裝注音 + 日文${NC}"
+            break
+            ;;
+        *)
+            echo -e "${RED}請輸入 1-4${NC}"
+            ;;
+    esac
+done
+
+echo
+for i in {3..1}; do
+    printf "\r將在 %d 秒後開始..." "$i"
+    sleep 1
+done
+echo
+
+echo
+echo "正在從 GitHub 取得檔案清單..."
+ALL_FILES=$(curl -fsSL --connect-timeout 10 --max-time 30 "$GITHUB_API" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    for item in data.get('tree', []):
+        if item.get('type') == 'blob':
+            print(item['path'])
+except:
+    pass
+" 2>/dev/null)
+
+if [ -z "$ALL_FILES" ]; then
+    echo -e "${RED}[錯誤] GitHub API 連線失敗${NC}"
+    echo "       請檢查網路連線，或稍後再試"
+    echo "       若持續失敗，請至 GitHub 手動下載："
+    echo "       https://github.com/${GITHUB_REPO}"
+    exit 1
+fi
+
+# 分類檔案
+ROOT_FILES=()
+LUA_FILES=()
+LUA_LUNAR_FILES=()
+OPENCC_FILES=()
+CONFIGS_FILES=()
+FONT_FILES=()
+
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+
+    # 檢查是否要排除
+    if echo "$file" | grep -qE "$EXCLUDE_PATTERNS"; then
+        continue
+    fi
+
+    # 根據路徑分類
+    if [[ "$file" == lua/lunar_calendar/* ]]; then
+        LUA_LUNAR_FILES+=("$file")
+    elif [[ "$file" == lua/* ]]; then
+        LUA_FILES+=("$file")
+    elif [[ "$file" == opencc/* ]]; then
+        OPENCC_FILES+=("$file")
+    elif [[ "$file" == configs/* ]]; then
+        CONFIGS_FILES+=("$file")
+    elif [[ "$file" == fonts/* ]]; then
+        FONT_FILES+=("$file")
+    elif [[ "$file" != */* ]]; then
+        ROOT_FILES+=("$file")
+    fi
+done <<< "$ALL_FILES"
+
+# 計算總檔案數
+TOTAL_FILES=$((${#ROOT_FILES[@]} + ${#LUA_FILES[@]} + ${#LUA_LUNAR_FILES[@]} + ${#OPENCC_FILES[@]} + ${#CONFIGS_FILES[@]}))
+echo "找到 $TOTAL_FILES 個方案檔案、${#FONT_FILES[@]} 個字體"
+
+echo
+echo "[ Step 1: 下載蝦米輸入方案檔案 ]"
+echo
+
+# 建立資料夾
+mkdir -p "$RIME_FOLDER"
+mkdir -p "$RIME_FOLDER/lua"
+mkdir -p "$RIME_FOLDER/lua/lunar_calendar"
+mkdir -p "$RIME_FOLDER/opencc"
+mkdir -p "$RIME_FOLDER/configs"
+
+# 建立共用 rime 預設檔案的符號連結（fcitx5-rime 需要這些）
+RIME_SHARED="/usr/share/rime-data"
+for preset in default.yaml key_bindings.yaml punctuation.yaml; do
+    if [ -f "$RIME_SHARED/$preset" ] && [ ! -f "$RIME_FOLDER/$preset" ]; then
+        ln -sf "$RIME_SHARED/$preset" "$RIME_FOLDER/$preset"
+    fi
+done
+
+CURRENT=0
+
+# 需要保留的自定義設定檔清單
+CUSTOM_FILES=("openxiami_CustomWord.dict.yaml" "default.custom.yaml")
+
+# 下載單一檔案的函數
+download_file() {
+    local url="$1"
+    local dest="$2"
+    local name="$3"
+    local current="$4"
+    local total="$5"
+
+    printf "  [%d/%d] %s ... " "$current" "$total" "$name"
+    if curl -fsSL --connect-timeout 10 --max-time 120 "$url" -o "$dest"; then
+        echo -e "${GREEN}ok${NC}"
+    else
+        echo -e "${RED}failed${NC}"
+    fi
+}
+
+# 下載主要檔案
+for file in "${ROOT_FILES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    if [[ " ${CUSTOM_FILES[*]} " =~ " ${file} " ]] && [ "$KEEP_CUSTOM_FILES" = true ] && [ -f "$RIME_FOLDER/$file" ]; then
+        echo "  [${CURRENT}/${TOTAL_FILES}] $file ... [保留]"
+    else
+        download_file "${GITHUB_RAW}/${file}" "$RIME_FOLDER/$file" "$file" $CURRENT $TOTAL_FILES
+    fi
+done
+
+# 下載 Lua 檔案
+for file in "${LUA_FILES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    filename=$(basename "$file")
+    download_file "${GITHUB_RAW}/${file}" "$RIME_FOLDER/lua/$filename" "$filename" $CURRENT $TOTAL_FILES
+done
+
+# 下載 Lua lunar_calendar 檔案
+for file in "${LUA_LUNAR_FILES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    filename=$(basename "$file")
+    download_file "${GITHUB_RAW}/${file}" "$RIME_FOLDER/lua/lunar_calendar/$filename" "$filename" $CURRENT $TOTAL_FILES
+done
+
+# 下載 OpenCC 檔案
+for file in "${OPENCC_FILES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    filename=$(basename "$file")
+    download_file "${GITHUB_RAW}/${file}" "$RIME_FOLDER/opencc/$filename" "$filename" $CURRENT $TOTAL_FILES
+done
+
+# 下載 Configs 檔案
+for file in "${CONFIGS_FILES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    filename=$(basename "$file")
+    download_file "${GITHUB_RAW}/${file}" "$RIME_FOLDER/configs/$filename" "$filename" $CURRENT $TOTAL_FILES
+done
+
+echo
+
+echo
+echo "[ Step 2: 配置輸入方案版本 ]"
+
+if [ "$SCHEMA_VERSION" = "mixed" ]; then
+    echo "正在配置完整版（中打含英文詞庫版）..."
+    cp "$RIME_FOLDER/configs/liur.schema.yaml" "$RIME_FOLDER/liur.schema.yaml"
+    echo -e "${GREEN}已配置為完整版（中打含英文詞庫版）${NC}"
+else
+    echo "正在配置基礎版（中打不含英文詞庫）..."
+    cp "$RIME_FOLDER/configs/liur.chinese-only.schema.yaml" "$RIME_FOLDER/liur.schema.yaml"
+    echo -e "${GREEN}已配置為基礎版（中打不含英文詞庫）${NC}"
+fi
+
+rm -rf "$RIME_FOLDER/configs" 2>/dev/null || true
+
+STEP=3
+
+# 安裝注音（條件式）
+if [ "$INSTALL_BOPOMOFO" = true ]; then
+    echo
+    echo "[ Step $STEP: 安裝注音輸入法（台灣注音） ]"
+    STEP=$((STEP + 1))
+
+    if pacman -Qi rime-bopomofo &>/dev/null; then
+        echo -e "${GREEN}rime-bopomofo（注音）已安裝${NC}"
+    else
+        echo "正在安裝 rime-bopomofo（台灣注音）..."
+        sudo pacman -S --noconfirm rime-bopomofo
+        echo -e "${GREEN}rime-bopomofo 安裝完成${NC}"
+    fi
+
+    # 移除不需要的中國輸入方案（若已安裝）
+    CHINA_SCHEMAS=("rime-cangjie" "rime-pinyin-simp" "rime-stroke" "rime-wubi")
+    for pkg in "${CHINA_SCHEMAS[@]}"; do
+        if pacman -Qi "$pkg" &>/dev/null; then
+            echo -e "${YELLOW}移除不需要的方案：${pkg}${NC}"
+            sudo pacman -Rns --noconfirm "$pkg" 2>/dev/null || true
+        fi
+    done
+fi
+
+# 安裝日文（條件式）
+if [ "$INSTALL_JAPANESE" = true ]; then
+    echo
+    echo "[ Step $STEP: 安裝日文輸入方案 ]"
+    STEP=$((STEP + 1))
+
+    JAPANESE_SCHEMA_REPO="gkovacs/rime-japanese"
+    JAPANESE_RAW="https://raw.githubusercontent.com/${JAPANESE_SCHEMA_REPO}/master"
+
+    echo "正在下載日文輸入方案 (rime-japanese)..."
+
+    JAPANESE_FILES=(
+        "japanese.schema.yaml"
+        "japanese.dict.yaml"
+        "japanese.mozc.dict.yaml"
+        "japanese.jmdict.dict.yaml"
+        "japanese.kana.dict.yaml"
+    )
+
+    for jfile in "${JAPANESE_FILES[@]}"; do
+        echo -n "  下載 $jfile ... "
+        if curl -fsSL --connect-timeout 10 --max-time 120 "${JAPANESE_RAW}/${jfile}" -o "$RIME_FOLDER/$jfile" 2>/dev/null; then
+            echo -e "${GREEN}完成${NC}"
+        else
+            echo -e "${RED}失敗（請檢查網路連線）${NC}"
+        fi
+    done
+
+    echo -e "${GREEN}日文輸入方案安裝完成${NC}"
+fi
+
+echo
+echo "[ Step $STEP: 配置 default.custom.yaml ]"
+STEP=$((STEP + 1))
+
+# 根據選擇建立 schema_list
+EXTRA_SCHEMAS=""
+EXTRA_SCHEMA_HINTS=""
+if [ "$INSTALL_BOPOMOFO" = true ]; then
+    EXTRA_SCHEMAS="${EXTRA_SCHEMAS}        - schema: bopomofo_tw
+"
+    EXTRA_SCHEMA_HINTS="${EXTRA_SCHEMA_HINTS}        - schema: bopomofo_tw
+"
+fi
+if [ "$INSTALL_JAPANESE" = true ]; then
+    EXTRA_SCHEMAS="${EXTRA_SCHEMAS}        - schema: japanese
+"
+    EXTRA_SCHEMA_HINTS="${EXTRA_SCHEMA_HINTS}        - schema: japanese
+"
+fi
+
+if [ "$KEEP_CUSTOM_FILES" = false ] || [ ! -f "$RIME_FOLDER/default.custom.yaml" ]; then
+    cat > "$RIME_FOLDER/default.custom.yaml" << YAML
+__patch:
+  - patch:
+      menu:
+        alternative_select_keys: "0123456789"	#重碼選擇鍵，從 0 開始
+        page_size: 5	#選單 每頁 顯示 個數
+      ascii_composer:
+        good_old_caps_lock: true
+        switch_key: {Caps_Lock: clear, Control_L: noop, Control_R: noop, Eisu_toggle: clear, Shift_L: commit_code, Shift_R: commit_code}
+      switcher/hotkeys:
+        - Control+grave
+        - Control+Shift+grave
+
+  - patch/+:
+      schema_list:
+        - schema: liur
+        - schema: easy_en
+${EXTRA_SCHEMAS}      switcher/fix_schema_list_order: true
+  - patch/key_binder/bindings/+:
+    - { when: always, accept: 'Control+slash', select: liur }
+    - { accept: period, send: period, when: has_menu }      # 輸入.
+    - { accept: "Control+period", toggle: simplification, when: always }    #進行簡繁切換
+    - { accept: "Control+apostrophe", toggle: liu_w2c, when: always }   #顯示字碼
+    - { accept: "Control+comma", toggle: extended_charset, when: always}
+    - { accept: "Shift+space", toggle: full_shape, when: always}
+    # 數字小鍵盤選字（從 0 開始，與主鍵盤一致）
+    - { accept: KP_0, send: 0, when: has_menu }
+    - { accept: KP_1, send: 1, when: has_menu }
+    - { accept: KP_2, send: 2, when: has_menu }
+    - { accept: KP_3, send: 3, when: has_menu }
+    - { accept: KP_4, send: 4, when: has_menu }
+    - { accept: KP_5, send: 5, when: has_menu }
+    - { accept: KP_6, send: 6, when: has_menu }
+    - { accept: KP_7, send: 7, when: has_menu }
+    - { accept: KP_8, send: 8, when: has_menu }
+    - { accept: KP_9, send: 9, when: has_menu }
+    - { when: composing, accept: Control+k, send: Shift+Delete }
+YAML
+    echo -e "${GREEN}default.custom.yaml 已配置${NC}"
+else
+    echo -e "${YELLOW}default.custom.yaml 已保留${NC}"
+    if [ -n "$EXTRA_SCHEMA_HINTS" ]; then
+        echo -e "${YELLOW}請手動加入以下方案到 schema_list：${NC}"
+        echo -n "$EXTRA_SCHEMA_HINTS"
+    fi
+fi
+
+echo
+echo "[ Step $STEP: 安裝字體 ]"
+STEP=$((STEP + 1))
+
+mkdir -p "$FONT_FOLDER"
+
+FONT_TOTAL=${#FONT_FILES[@]}
+FONT_CURRENT=0
+
+for file in "${FONT_FILES[@]}"; do
+    FONT_CURRENT=$((FONT_CURRENT + 1))
+    filename=$(basename "$file")
+    if [ -f "$FONT_FOLDER/$filename" ]; then
+        echo "  [${FONT_CURRENT}/${FONT_TOTAL}] $filename ... [skip]"
+    else
+        download_file "${GITHUB_RAW}/${file}" "$FONT_FOLDER/$filename" "$filename" $FONT_CURRENT $FONT_TOTAL
+    fi
+done
+
+# 更新字體快取
+echo "正在更新字體快取..."
+fc-cache -f "$FONT_FOLDER" 2>/dev/null || true
+echo -e "${GREEN}字體快取已更新${NC}"
+
+echo
+echo "[ Step $STEP: 部署 RIME ]"
+
+if command -v fcitx5-remote &>/dev/null; then
+    echo "正在重新部署 fcitx5-rime..."
+    fcitx5-remote -r 2>/dev/null || true
+    sleep 1
+    # 觸發 rime 重新部署
+    if command -v rime_deployer &>/dev/null; then
+        rime_deployer --build "$RIME_FOLDER" 2>/dev/null || true
+    fi
+    fcitx5-remote -r 2>/dev/null || true
+    echo -e "${GREEN}已重新部署 fcitx5-rime${NC}"
+else
+    echo -e "${YELLOW}無法自動部署，請手動重新啟動 fcitx5${NC}"
+    echo "  可嘗試：fcitx5 -r -d"
+fi
+
+echo
+echo "======================================"
+echo -e "${GREEN}  蝦米輸入方案 安裝完成 可開始使用${NC}"
+echo "======================================"
+echo
+echo "Rime 資料夾：$RIME_FOLDER"
+echo "字體資料夾：$FONT_FOLDER"
+echo
+echo "可用的輸入方案："
+echo "  - liur（蝦米）"
+echo "  - easy_en（英文）"
+[ "$INSTALL_BOPOMOFO" = true ] && echo "  - bopomofo_tw（台灣注音）"
+[ "$INSTALL_JAPANESE" = true ] && echo "  - japanese（日文）"
+echo
+echo "切換方案：Ctrl+\` 或 Ctrl+Shift+\`"
+echo
+echo "更多資訊請參考：https://ryanwuson.github.io/rime-liur/"


### PR DESCRIPTION
## 摘要

- 新增 `rime_liur_installer_linux.sh` 安裝腳本，支援 Arch Linux 及 Debian/Ubuntu 的 fcitx5-rime 環境
- 更新 `README.md`，加入 Linux 安裝指南（繁體中文）

## 安裝腳本功能

- 支援完整版（含英文詞庫）或基礎版（純中文）選擇
- 可選安裝台灣注音（bopomofo）及日文輸入（rime-japanese）
- 自動建立共用預設檔案的符號連結（`default.yaml`、`key_bindings.yaml`、`punctuation.yaml`）
- 自動安裝字體並更新字體快取
- 自動重新部署 fcitx5-rime

## README 更新內容

- 新增 Linux（Arch / Debian / Ubuntu）前置需求說明
- 新增自動安裝及手動安裝步驟
- 新增額外輸入方案（注音、日文）安裝說明

## 測試計畫

- [x] 在 Arch Linux 上測試自動安裝腳本
- [ ] 在 Debian/Ubuntu 上測試自動安裝腳本
- [x] 驗證符號連結正確建立
- [x] 驗證 fcitx5-rime 部署成功
- [x] 確認 README 說明步驟可正確操作